### PR TITLE
KEYCLOAK-10120: enable statistics with env variable

### DIFF
--- a/server/README.md
+++ b/server/README.md
@@ -315,7 +315,19 @@ containing a `crt` file and point `X509_CA_BUNDLE` environmental variable to tha
 
 NOTE: See `openshift-examples` directory for an out of the box setup for OpenShift.
 
+### Enable some metrics
 
+Keycloak image can collect some statistics for various subsystem which will then be available in the management console and the `/metrics` endpoint.
+You can enable it with the following environment variables :
+* `WILDFLY_DATASOURCES_STATISTICS_ENABLED` for the `datasources` subsystem
+* `WILDFLY_EJB3_STATISTICS_ENABLED` for the `ejb3` subsystem
+* `WILDFLY_TRANSACTIONS_STATISTICS_ENABLED` for the `transactions` subsystem
+* `WILDFLY_UNDERTOW_STATISTICS_ENABLED` for the `undertow` subsystem
+* `WILDFLY_JGROUPS_STATISTICS_ENABLED` for the `jgroups` subsystem
+
+You can also enable all of those with `WILDFLY_STATISTICS_ENABLED`.
+
+Once enabled, you should see the metrics values changing on the `/metrics` endpoint for the management endpoint.
 
 ## Other details
 

--- a/server/tools/cli/statistics.cli
+++ b/server/tools/cli/statistics.cli
@@ -1,0 +1,10 @@
+embed-server --server-config=standalone-ha.xml --std-out=echo
+batch
+/subsystem=datasources/data-source=KeycloakDS:write-attribute(name=statistics-enabled, value=${env.WILDFLY_DATASOURCES_STATISTICS_ENABLED:${env.WILDFLY_STATISTICS_ENABLED:false}})
+/subsystem=datasources/data-source=ExempleDS:write-attribute(name=statistics-enabled, value=${env.WILDFLY_DATASOURCES_STATISTICS_ENABLED:${env.WILDFLY_STATISTICS_ENABLED:false}})
+/subsystem=ejb3:write-attribute(name=enable-statistics,value=${env.WILDFLY_EJB3_STATISTICS_ENABLED:${env.WILDFLY_STATISTICS_ENABLED:false}})
+/subsystem=transactions:write-attribute(name=enable-statistics, value=${env.WILDFLY_TRANSACTIONS_STATISTICS_ENABLED:${env.WILDFLY_STATISTICS_ENABLED:false}})
+/subsystem=undertow:write-attribute(name=statistics-enabled,value=${env.WILDFLY_UNDERTOW_STATISTICS_ENABLED:${env.WILDFLY_STATISTICS_ENABLED:false}})
+/subsystem=jgroups/channel=ee:write-attribute(name=statistics-enabled, value=${env.WILDFLY_JGROUPS_STATISTICS_ENABLED:${env.WILDFLY_STATISTICS_ENABLED:false}})
+run-batch
+stop-embedded-server

--- a/server/tools/docker-entrypoint.sh
+++ b/server/tools/docker-entrypoint.sh
@@ -164,6 +164,7 @@ fi
 
 /opt/jboss/tools/x509.sh
 /opt/jboss/tools/jgroups.sh $JGROUPS_DISCOVERY_PROTOCOL $JGROUPS_DISCOVERY_PROPERTIES
+/opt/jboss/tools/statistics.sh
 /opt/jboss/tools/autorun.sh
 
 ##################

--- a/server/tools/statistics.sh
+++ b/server/tools/statistics.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+$JBOSS_HOME/bin/jboss-cli.sh --file="/opt/jboss/tools/cli/statistics.cli" >& /dev/null


### PR DESCRIPTION
The CLI is run at runtime, when all the other configuration is done
(jgroups and database).

<!---
Please read https://github.com/keycloak/keycloak/blob/master/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
